### PR TITLE
Update API_KEY to use environment variables for security purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ venv/
 users.db
 __pycache__/
 *.pyc
+.env
 

--- a/app.py
+++ b/app.py
@@ -6,13 +6,21 @@ import requests
 from datetime import datetime
 from math import ceil, log2
 
+import os
+from dotenv import load_dotenv
+
 BASE_DIR = Path(__file__).parent
 DATABASE = BASE_DIR / "users.db"
 
 app = Flask(__name__)
 app.secret_key = "key" # TODO: Get secret key
 
-API_KEY = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiIsImtpZCI6IjI4YTMxOGY3LTAwMDAtYTFlYi03ZmExLTJjNzQzM2M2Y2NhNSJ9.eyJpc3MiOiJzdXBlcmNlbGwiLCJhdWQiOiJzdXBlcmNlbGw6Z2FtZWFwaSIsImp0aSI6IjBkMWI4YmYxLWYyNzAtNGZmNy1iOTlhLWFmZjFhNTRjMDg5OCIsImlhdCI6MTc2NDI1NzQyMSwic3ViIjoiZGV2ZWxvcGVyL2Y3YjA5OWM3LTViZmItNDJhOC1mYzUzLTUzNWRjODI4NTJiMCIsInNjb3BlcyI6WyJyb3lhbGUiXSwibGltaXRzIjpbeyJ0aWVyIjoiZGV2ZWxvcGVyL3NpbHZlciIsInR5cGUiOiJ0aHJvdHRsaW5nIn0seyJjaWRycyI6WyI3My4xMjYuMTQyLjExIl0sInR5cGUiOiJjbGllbnQifV19.zNv5pei5V-J_q7QzrLVCRhiC4GACsWIktZ8V43ruv9RUvJkTyi7fCAmsHaqLM75cC3bVXOtRuRerc5N9HGUIoA"
+
+dotenv_path = Path(".env")
+load_dotenv(dotenv_path=dotenv_path)
+
+# Load the API_KEY from .env
+API_KEY = os.getenv('API_KEY')
 
 # Connect to database
 def get_db():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=2.0
 Werkzeug>=2.0
+dotenv


### PR DESCRIPTION
## Summary
This PR removes the hardcoded API key from `app.py` and replaces it with a more secure, environment variable approach.


## Why
Including the API key in github is a big security vulnerability as it allows anyone who can see the repo to use the API as if they were the account owner.

This branch pulls the API key out of app.py and instead replaces it with an environment variable stored in `.env`. The `.env` file has been added to `.gitignore` so that nobody can access it from the github repo.

## Changes
- Replaced API_KEY string with .env sourced API_KEY variable
- Added `.env` to `.gitignore`
- Added `python-dotenv` to the requirements.txt

## How to use
1. Create a `.env` file in your project root
2. Add the following line:
```bash
API_KEY=your_key
```
3. The app will load the key when ran
---

I recommend generating a new API key as well, since commit history is public so somebody could still access your key and use it for nefarious purposes.